### PR TITLE
Dependabot ignore patch releases

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -10,3 +10,6 @@ updates:
   schedule:
     interval: weekly
     time: "13:00"
+  ignore:
+    - dependency-name: "*"
+      update-types: ["version-update:semver-patch"]


### PR DESCRIPTION
Dependabot is generating a large amount of PRs for every patch release. It will now only create a PR for minor or major releases.